### PR TITLE
Change default scope to new profile scope

### DIFF
--- a/demo.html
+++ b/demo.html
@@ -13,7 +13,7 @@
   <p>A `google-signin` looks like this:</p>
   <div id="status"></div>
 
-  <google-signin clientId="400542164111-q94vcbin3jp3fb2a0su1nm6gt4qpf86t.apps.googleusercontent.com" scopes="https://www.googleapis.com/auth/userinfo.profile"></google-signin>
+  <google-signin clientId="400542164111-q94vcbin3jp3fb2a0su1nm6gt4qpf86t.apps.googleusercontent.com" scopes="profile"></google-signin>
 
   <script>
       document.addEventListener("google-signin-success", function(){

--- a/google-signin.html
+++ b/google-signin.html
@@ -98,7 +98,7 @@ process.
                 /**
                  * The scopes to provide access to (e.g https://www.googleapis.com/auth/drive)
                  */
-                scopes: 'https://www.googleapis.com/auth/userinfo.profile',
+                scopes: 'profile',
                 /**
                  * An optional label for the sign-in button
                  */


### PR DESCRIPTION
I've tested this with the following commands after authenticating:

```
gapi.client.load("plus", "v1")
...
gapi.client.plus.people.get({"userId": "me"}).execute(function(r) { console.log(r); })
```

Which correctly returned my profile information. (provided the Google+ API is activated in the developers console)

Btw: It might be worth adding a note to the description of the element, that multiple scopes should be space-delimited
