### PR TITLE
Change to page-level configuration for signout

### DIFF
--- a/google-signin.html
+++ b/google-signin.html
@@ -74,7 +74,7 @@ case. Both events will also provide the data returned by the Google client authe
 
                 } else {
                     if (authResult && authResult.error == "user_signed_out") {
-                        // Fire event to indicate sign-in was not successful
+                        // Fire event to indicate user signed out
                         handler.fire('google-signed-out', {result: authResult});
                     } else {
                         // Fire event to indicate sign-in was not successful
@@ -86,7 +86,7 @@ case. Both events will also provide the data returned by the Google client authe
                     authButton.style.display = 'block';
 
                     authButton.onclick = function() {
-                      gapi.auth.signIn();
+                        gapi.auth.signIn();
                     };
                 }
             }


### PR DESCRIPTION
Sign-out is a bit of a hassle (as you have experienced yourself).

The `gapi.auth.signOut()` method doesn't accept a callback function (which might be worth adding as issue/request to the relevant team, not sure if Google+ or JS-Client).

The only way I got it to work is to use page-level configuration with meta tags and then using the `gapi.auth.signIn()` / `gapi.auth.signOut()` methods, which always call the same callback function, which unfortunately has be referenced from global namespace.

With page-level configuration the immediate flow will be triggered automatically once gapi is loaded, so no need to check for this (but also no way to prevent this behaviour, except by setting `google-signin-approvalprompt` to `force` in the meta tags)

I understand if you don't want to merge this, but it's the only way I found to make the sign-out work
