### PR TITLE
Fire additional event for incremental auth scenarios

### DIFF
--- a/google-signin.html
+++ b/google-signin.html
@@ -35,6 +35,9 @@ will also provide the data returned by the Google client authentication process.
 Additional events, such as `google-signout-attempted` and `google-signed-out` are
 triggered when the user attempts to sign-out and successfully signs out.
 
+The `google-signin-necessary` event is fired when scopes requested via
+google-signin-aware elements require additional user permissions.
+
 ##### Example
 
     <google-signin cliendId="..." scopes="https://www.googleapis.com/auth/drive"></google-signin>
@@ -86,6 +89,7 @@ triggered when the user attempts to sign-out and successfully signs out.
                     if (SCOPES[i] !== '') {
                         if (authorized_scopes.indexOf(SCOPES[i].toLowerCase()) < 0) {
                             handler.additionalAuth = true;
+                            handler.fire('google-signin-necessary');
                             break;
                         }
                     }
@@ -283,6 +287,7 @@ triggered when the user attempts to sign-out and successfully signs out.
                     if (extra_scopes) {
                         if (handler.flowComplete) {
                             handler.additionalAuth = true;
+                            handler.fire('google-signin-necessary');
                         }
                     } else {
                         handler.fire('polymer-signal', {


### PR DESCRIPTION
This would allow custom sign-in elements to make use of the full `google-signin` functionality.

In [my sample for custom sign-in](https://github.com/Scarygami/google-signin-samples/blob/master/elements/custom-google-signin.html) I can only have sign-in and sign-out buttons since I won't be notified about additional necessary permissions with the current implementation.
