### PR TITLE
Fixed styling in docs for `google-signin-aware-signed-out`.

### DIFF
--- a/google-signin.html
+++ b/google-signin.html
@@ -412,7 +412,7 @@ authentication process.
 The `google-signin-aware-success` event is triggered when a user successfully
 authenticates and `google-signin-aware-failure` is triggered when this is not
 he case. Both events will also provide the data returned by the Google client
-authentication process. The `google-signin-aware-signed-out' event is triggered
+authentication process. The `google-signin-aware-signed-out` event is triggered
 when a user explicitely signs out via the google-signin element.
 
 ##### Example


### PR DESCRIPTION
Changed a single quote to an accent character.  The current problem can be seen in paragraph four [here](http://googlewebcomponents.github.io/google-signin/components/google-signin/#google-signin-aware).
