### PR TITLE
Pass all parameters into gapi.auth.signIn

### DIFF
--- a/google-signin.html
+++ b/google-signin.html
@@ -165,7 +165,7 @@ google-signin-aware elements require additional user permissions.
              *
              * @event google-signout-attempted
              */
-                        
+
             /**
              * Called when the user has completed sign-out.
              *
@@ -369,7 +369,13 @@ google-signin-aware elements require additional user permissions.
 
                 signIn: function () {
                     handler.flowComplete = false;
-                    gapi.auth.signIn({'scope': SCOPES.join(' ')});
+                    gapi.auth.signIn({
+                        'clientid': CLIENT_ID,
+                        'cookiepolicy': COOKIE_POLICY,
+                        'scope': SCOPES.join(' '),
+                        'requestvisibleactions': REQUEST_VISIBLE_ACTIONS,
+                        'callback': 'handleAuthResult'
+                    });
                 },
 
                 signInKeyPress: function (e) {


### PR DESCRIPTION
This solves issues that happen when gapi is already loaded before the element is rendered.
In this case gapi won't read the global configuration from the meta tags and any gapi.auth calls will fail.

Should fix https://github.com/GoogleWebComponents/google-signin/issues/15

Note that while sign-in works in all cases that way, automatic sign-in when re-visiting a page won't work if gapi has been loaded "too early".
