### PR TITLE
App package name support for over-the-air installs

### DIFF
--- a/google-signin.html
+++ b/google-signin.html
@@ -427,6 +427,7 @@ google-signin-aware elements require additional user permissions.
                  *
                  * @attribute appPackageName
                  * @type string
+                 * @default ''
                  */
                 appPackageName: '',
                 /**
@@ -580,7 +581,7 @@ google-signin-aware elements require additional user permissions.
 
                     // Proxy specific attributes through to the signIn.
                     Object.keys(ProxyLoginAttributes).forEach(function(key) {
-                        if (handler[key] && handler[key] != '') {
+                        if (handler[key] && handler[key] !== '') {
                             params[ProxyLoginAttributes[key]] = handler[key];
                         }
                     });


### PR DESCRIPTION
Adding the `appPackageName` attribute to support OTA installs for android apps.
