### PR TITLE
Removing the meta page-level configuration for the signin.

### DIFF
--- a/google-signin.html
+++ b/google-signin.html
@@ -553,7 +553,7 @@ google-signin-aware elements require additional user permissions.
 
                     // If there is no flow state then start an immediate auth check.
                     if (flowComplete === null) {
-                        params.immediate_mode = true;
+                        params.immediate = true;
                     }
 
                     flowComplete = false;


### PR DESCRIPTION
The page level meta tags are not needed when using the JS `signIn()` to trigger the authentication.
