### PR TITLE
Updating the doc string for the `signed-out` event to be separate.

### DIFF
--- a/google-signin.html
+++ b/google-signin.html
@@ -305,10 +305,16 @@ google-signin-aware elements require additional user permissions.
              */
 
             /**
-             * Called when the user has completed sign-out.
+             * Called when the user is signed-out.
+             *
+             * @param {Object} result Authorization result.
+             * @event google-signed-out
+             */
+
+            /**
+             * Called when the authentication result is complete.
              *
              * @param {Object} authResult Authorization result.
-             * @event google-signed-out
              */
             function handleAuthResult(authResult) {
                 if (authResult && !authResult.error) {


### PR DESCRIPTION
The doc string looked like it belonged to the handler for the auth result.
