### PR TITLE
Change when google-signin-aware requests auth

### DIFF
--- a/google-signin.html
+++ b/google-signin.html
@@ -742,7 +742,7 @@ when a user explicitely signs out via the google-signin element.
                  */
                 scopes: '',
 
-                attached: function() {
+                domReady: function() {
                     this.fire('core-signal', {
                         name: 'google-auth-request',
                         data: this.scopes


### PR DESCRIPTION
By requesting in domReady, we know all our children (the signal handlers) are ready before we call into google-signin code.

I realized this potential fix for #47 right after I filed it.
