### PR TITLE
Offline attribute for the latest signin library

### DIFF
--- a/google-signin.html
+++ b/google-signin.html
@@ -59,6 +59,9 @@ will also provide the data returned by the Google client authentication process.
 Additional events, such as `google-signout-attempted` and `google-signed-out` are
 triggered when the user attempts to sign-out and successfully signs out.
 
+When requesting offline access, the `google-signin-offline` event is triggered when
+the user successfully consents with offline support.
+
 The `google-signin-necessary` event is fired when scopes requested via
 google-signin-aware elements require additional user permissions.
 
@@ -220,6 +223,13 @@ any apps you're building. See the Google Developers Console
        *
        * @param {Object} result Authorization result.
        * @event google-signin-success
+       */
+
+      /**
+       * Called when an offline authorization is successful.
+       *
+       * @param {string} code Authorization one-time offline code.
+       * @event google-signin-offline
        */
 
       /**
@@ -493,6 +503,15 @@ any apps you're building. See the Google Developers Console
            * @default 'Sign out'
            */
           labelSignout: 'Sign out',
+
+          /**
+           * Allows for offline access_token retrieval during the signin process.
+           *
+           * @attribute offline
+           * @type boolean
+           * @default false
+           */
+          offline: false,
 
           /**
            * If true, the button will be styled with a shadow.

--- a/google-signin.html
+++ b/google-signin.html
@@ -228,7 +228,7 @@ any apps you're building. See the Google Developers Console
       /**
        * Called when an offline authorization is successful.
        *
-       * @param {Object} result Result with one-time offline code.
+       * @param String code Result with one-time offline code.
        * @event google-signin-offline
        */
 
@@ -577,11 +577,15 @@ any apps you're building. See the Google Developers Console
           }, this);
 
           if(this.offline) {
-            var handler = this;
+            params['redirect_uri'] = 'postmessage';
+
             auth.grantOfflineAccess(params).then(function(response) {
-              // Trigger the offline code.
-              handler.fire('google-signin-offline', response);
-            }, function(error) {
+              if(response.code) {
+                this.fire('google-signin-offline', response.code);
+              }
+
+              // Let the current user listener trigger the changes.
+            }.bind(this), function(error) {
               console.error(error);
             });
           } else {

--- a/google-signin.html
+++ b/google-signin.html
@@ -228,7 +228,7 @@ any apps you're building. See the Google Developers Console
       /**
        * Called when an offline authorization is successful.
        *
-       * @param {string} code Authorization one-time offline code.
+       * @param {Object} result Result with one-time offline code.
        * @event google-signin-offline
        */
 
@@ -576,11 +576,21 @@ any apps you're building. See the Google Developers Console
             }
           }, this);
 
-          auth.signIn(params).then(function(newUser) {
-            // Let the current user listener trigger the changes.
-          }, function(error) {
-            console.error(error);
-          });
+          if(this.offline) {
+            var handler = this;
+            auth.grantOfflineAccess(params).then(function(response) {
+              // Trigger the offline code.
+              handler.fire('google-signin-offline', response);
+            }, function(error) {
+              console.error(error);
+            });
+          } else {
+            auth.signIn(params).then(function(newUser) {
+              // Let the current user listener trigger the changes.
+            }, function(error) {
+              console.error(error);
+            });
+          }
         },
 
         signedIn: false,


### PR DESCRIPTION
Triggers the `git push --set-upstream origin api2.0-offline` when code is present in the auth response for offline access.

Fixes #85.