### PR TITLE
fix #93. update docs, better error message

### DIFF
--- a/google-signin-aware.html
+++ b/google-signin-aware.html
@@ -298,8 +298,22 @@
           return this._grantedScopeArray.indexOf(scope) === -1;
         }.bind(this)).join(' ');
       },
+
+      assertAuthInitialized: function() {
+        if (!this.clientId) {
+          throw new Error("AuthEngine not initialized. clientId has not been configured.");
+        }
+        if (!('gapi' in window)) {
+          throw new Error("AuthEngine not initialized. gapi has not loaded.");
+        }
+        if (!('auth2' in window.gapi)) {
+          throw new Error("AuthEngine not initialized. auth2 not loaded.");
+        }
+      },
+
       /** pops up sign-in dialog */
       signIn: function() {
+        this.assertAuthInitialized();
         var params = {
           'scope': this.getMissingScopes()
         };
@@ -338,6 +352,7 @@
 
       /** signs user out */
       signOut: function() {
+        this.assertAuthInitialized();
         gapi.auth2.getAuthInstance().signOut().then(
           function success() {
           // Let the current user listener trigger the changes.

--- a/google-signin.html
+++ b/google-signin.html
@@ -121,11 +121,11 @@ with other Google APIs such as Drive and Google+.
 
 #### Examples
 
-    <google-signin clientId="..." scopes="https://www.googleapis.com/auth/drive"></google-signin>
+    <google-signin client-id="..." scopes="https://www.googleapis.com/auth/drive"></google-signin>
 
-    <google-signin labelSignin="Sign-in" clientId="..." scopes="https://www.googleapis.com/auth/drive"></google-signin>
+    <google-signin label-signin="Sign-in" client-id="..." scopes="https://www.googleapis.com/auth/drive"></google-signin>
 
-    <google-signin theme="dark" width="iconOnly" clientId="..." scopes="https://www.googleapis.com/auth/drive"></google-signin>
+    <google-signin theme="dark" width="iconOnly" client-id="..." scopes="https://www.googleapis.com/auth/drive"></google-signin>
 
 #### Notes
 
@@ -167,6 +167,7 @@ port 8080. That said, you *should* update the `clientId` to your own one for
 any apps you're building. See the Google Developers Console
 (https://console.developers.google.com) for more info.
 
+@demo
 */
 
     Polymer({


### PR DESCRIPTION
Several fixes from bug #93 
- client-id instead of clientId in docs
- add @demo to docs
- add asserts with better error message to signIn, signOut methods