### PR TITLE
Add new forceOffline parameter

### DIFF
--- a/google-signin-aware.html
+++ b/google-signin-aware.html
@@ -127,6 +127,18 @@
         this.updateAdditionalAuth();
       },
 
+      /** Should we force a re-prompt for offline access? */
+      _offlineAlwaysPrompt: false,
+
+      get offlineAlwaysPrompt() {
+        return this._offlineAlwaysPrompt;
+      },
+
+      set offlineAlwaysPrompt(val) {
+        this._offlineAlwaysPrompt = val;
+        this.updateAdditionalAuth();
+      },
+
       /** Have we already gotten offline access from Google during this session? */
       offlineGranted: false,
 
@@ -277,7 +289,7 @@
       /** update status of _needAdditionalAuth */
       updateAdditionalAuth: function() {
         var needMoreAuth = false;
-        if (this.offline && !this.offlineGranted) {
+        if ((this.offlineAlwaysPrompt || this.offline ) && !this.offlineGranted) {
           needMoreAuth = true;
         } else {
           for (var i=0; i<this._requestedScopeArray.length; i++) {
@@ -371,7 +383,7 @@
 
         var promise;
         var user = gapi.auth2.getAuthInstance().currentUser.get();
-        if (!this.offline) {
+        if (!(this.offline || this.offlineAlwaysPrompt)) {
           if (user.getGrantedScopes()) {
             // additional auth, skip multiple account dialog
             promise = user.grant(params);
@@ -381,6 +393,9 @@
           }
         } else {
           params.redirect_uri = 'postmessage';
+          if (this.offlineAlwaysPrompt) {
+            params.approval_prompt = 'force';
+          }
 
           // Despite being documented at https://goo.gl/tiO0Bk
           // It doesn't seem like user.grantOfflineAccess() actually exists in
@@ -441,8 +456,8 @@ The `scopes` attribute allows you to specify which scope permissions are require
 (e.g do you want to allow interaction with the Google Drive API).
 
 The `google-signin-aware-success` event is triggered when a user successfully
-authenticates. If `offline` is set to true, successful authentication will also
-trigger the `google-signin-offline-success`event.
+authenticates. If either `offline` or `offlineAlwaysPrompt` is set to true, successful
+authentication will also trigger the `google-signin-offline-success`event.
 The `google-signin-aware-signed-out` event is triggered when a user explicitly
 signs out via the google-signin element.
 
@@ -543,11 +558,26 @@ You can bind to `isAuthorized` property to monitor authorization state.
 
        /**
          * Allows for offline `access_token` retrieval during the signin process.
+         * See also `offlineAlwaysPrompt`. You only need to set one of the two; if both
+         * are set, the behavior of `offlineAlwaysPrompt` will override `offline`.
          */
         offline: {
           type: Boolean,
           value: false,
           observer: '_offlineChanged'
+        },
+
+        /**
+          * Works the same as `offline` with the addition that it will always
+          * force a re-prompt to the user, guaranteeing that you will get a
+          * refresh_token even if the user has already granted offline access to
+          * this application. You only need to set one of `offline` or
+          * `offlineAlwaysPrompt`, not both.
+          */
+        offlineAlwaysPrompt: {
+          type: Boolean,
+          value: false,
+          observer: '_offlineAlwaysPromptChanged'
         },
 
        /**
@@ -639,6 +669,10 @@ You can bind to `isAuthorized` property to monitor authorization state.
 
       _offlineChanged: function(newVal, oldVal) {
         AuthEngine.offline = newVal;
+      },
+
+      _offlineAlwaysPromptChanged: function(newVal, oldVal) {
+        AuthEngine.offlineAlwaysPrompt = newVal;
       },
 
       _scopesChanged: function(newVal, oldVal) {

--- a/google-signin.html
+++ b/google-signin.html
@@ -19,6 +19,7 @@
       request-visible-actions="{{requestVisibleActions}}"
       hosted-domain="{{hostedDomain}}"
       offline="{{offline}}"
+      offline-always-prompt="{{offlineAlwaysPrompt}}"
       scopes="{{scopes}}"
       signed-in="{{signedIn}}"
       is-authorized="{{isAuthorized}}"
@@ -149,6 +150,9 @@ plus.login scope (https://www.googleapis.com/auth/plus.login).
 The `offline` attribute allows you to get an auth code which your server can
 redeem for an offline access token
 (https://developers.google.com/identity/sign-in/web/server-side-flow).
+You can also set `offline-always-prompt` instead of `offline` to ensure that your app
+will re-prompt the user for offline access and generate a working `refresh_token`
+even if they have already granted offline access to your app in the past.
 
 Use label properties to customize prompts.
 
@@ -343,6 +347,16 @@ any apps you're building. See the Google Developers Console
          * Allows for offline `access_token` retrieval during the signin process.
          */
         offline: {
+          type: Boolean,
+          value: false
+        },
+
+        /**
+         * Forces a re-prompt, even if the user has already granted offline
+         * access to your application in the past. You only need one of
+         * `offline` and `offlineAlwaysPrompt`.
+         */
+        offlineAlwaysPrompt: {
           type: Boolean,
           value: false
         },


### PR DESCRIPTION
Per the "Important" note under https://developers.google.com/identity/protocols/OAuth2WebServer#offline (then click on HTTP/REST), the code you get back from GrantOfflineAccess will only actually be valid for a refresh_token (the thing you need for offline access to work) the first time your app requests offline access for a given user.

In order to actually get a refresh_token in subsequent requests, you need to set approval_prompt="force". In my current application I need to set this value to true always, because I want to get multiple refresh_tokens per user. The consequence is that even if this user has authenticated to this application before, it forces a popup re-confirming that you want offline access.

For the google-signin component I think we have three options:
(1) Always set approval_prompt = "force" when using offline mode
(2a) Add another property like "force-offline" which controls setting approval_prompt, and works in addition to "offline" (so you'd set both "offline" and "force-offline" to have it active)
(2b) Add a property like "force-offline" that replaces "offline", so you only need to set one or the other

In this change I've implemented (2b), but am happy to change to another solution if any of you have ideas about how it will be used.

I was kind of tempted to just go with (1) because the behavior of requesting offline access but not actually receiving a working offline token is super confusing to me, but given that the API gives you both options I think it's better to expose that complexity.
