### PR TITLE
Remove unnecessary iron-icons import.

### DIFF
--- a/google-signin.html
+++ b/google-signin.html
@@ -1,7 +1,6 @@
 <link rel="import" href="../polymer/polymer.html">
 <link rel="import" href="google-signin-aware.html">
 <link rel="import" href="../iron-icon/iron-icon.html">
-<link rel="import" href="../iron-icons/iron-icons.html">
 <link rel="import" href="../font-roboto/roboto.html">
 <link rel="import" href="../google-apis/google-js-api.html">
 <link rel="import" href="../paper-ripple/paper-ripple.html">


### PR DESCRIPTION
Looks like you created the google-icons.html file, but never removed this one. The import adds a hefty 69K to any page that uses it. Can we remove it?