### PR TITLE
Add iron-iconset-svg to bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -25,6 +25,7 @@
     "polymer": "Polymer/polymer#^1.0.0",
     "font-roboto": "PolymerElements/font-roboto#^1.0.0",
     "iron-icon": "PolymerElements/iron-icon#^1.0.0",
+    "iron-iconset-svg": "PolymerElements/iron-iconset-svg#^1.0.0",
     "iron-flex-layout": "PolymerElements/iron-flex-layout#^1.0.0",
     "paper-ripple": "PolymerElements/paper-ripple#^1.0.0",
     "paper-material": "PolymerElements/paper-material#^1.0.0",


### PR DESCRIPTION
google-icons.html [depends on](https://github.com/GoogleWebComponents/google-signin/blob/91d6c2f8967992488fe25e8ec938a1d7364feeac/google-icons.html#L12) `iron-iconset-svg` element, but it is not reflected in bower.json. Add it to bower.json