### PR TITLE
Add openidPrompt property

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -96,12 +96,12 @@ or like this if plus scopes are present
           <option value="profile">Profile info</option>
         </select>
       </div>
-      <div>prompt=
-        <input type="checkbox" checked="{{prompt.none::change}}">none
-        <input type="checkbox" checked="{{prompt.login::change}}">login
-        <input type="checkbox" checked="{{prompt.consent::change}}">consent
+      <div>openid-prompt=
+        <input type="checkbox" checked="{{openidPrompt.none::change}}">none
+        <input type="checkbox" checked="{{openidPrompt.login::change}}">login
+        <input type="checkbox" checked="{{openidPrompt.consent::change}}">consent
         <input type="checkbox"
-            checked="{{prompt.select_account::change}}">select_account
+            checked="{{openidPrompt.select_account::change}}">select_account
       </div>
       <div>offline=<input type="checkbox" checked="{{offline::change}}"></div>
       <div>signedIn="<span>{{signedIn}}</span>"</div>
@@ -114,7 +114,7 @@ or like this if plus scopes are present
     </p>
     <google-signin-aware
         scopes="{{scope}}"
-        prompt="{{promptValue}}"
+        openid-prompt="{{openidPromptValue}}"
         signed-in="{{signedIn}}"
         offline="{{offline}}"
         is-authorized="{{isAuthorized}}"
@@ -132,7 +132,7 @@ or like this if plus scopes are present
     aware.status = 'Not granted';
     aware.offlineCode = 'No offline login.';
     aware.userName = 'N/A';
-    aware.prompt = {};
+    aware.openidPrompt = {};
     aware.handleSignIn = function(response) {
       this.status = 'Signin granted';
       // console.log('[Aware] Signin Response', response);
@@ -155,28 +155,28 @@ or like this if plus scopes are present
       gapi.auth2.getAuthInstance().signOut();
     };
 
-    aware.addEventListener('prompt-changed', function (e) {
+    aware.addEventListener('openid-prompt-changed', function (e) {
       if (e.detail.value) {
-        if (e.detail.path === 'prompt.none') {
-          aware.set('prompt', {
+        if (e.detail.path === 'openidPrompt.none') {
+          aware.set('openidPrompt', {
             none: true,
             login: false,
             consent: false,
             select_account: false
           });
         } else {
-          aware.set('prompt.none', false);
+          aware.set('openidPrompt.none', false);
         }
       }
 
       var values = [];
-      Object.keys(aware.prompt).forEach(function(k) {
-        if (aware.prompt[k]) {
+      Object.keys(aware.openidPrompt).forEach(function(k) {
+        if (aware.openidPrompt[k]) {
           values.push(k);
         }
       });
       //this.promptValue = values.join(' ');
-      this.set('promptValue', values.join(' '))
+      this.set('openidPromptValue', values.join(' '))
     });
 
   </script>

--- a/demo/index.html
+++ b/demo/index.html
@@ -155,7 +155,7 @@ or like this if plus scopes are present
       gapi.auth2.getAuthInstance().signOut();
     };
 
-    aware.addEventListener('openid-prompt-changed', function (e) {
+    aware.addEventListener('openid-prompt-changed', function(e) {
       if (e.detail.value) {
         if (e.detail.path === 'openidPrompt.none') {
           aware.set('openidPrompt', {
@@ -175,8 +175,7 @@ or like this if plus scopes are present
           values.push(k);
         }
       });
-      //this.promptValue = values.join(' ');
-      this.set('openidPromptValue', values.join(' '))
+      this.set('openidPromptValue', values.join(' '));
     });
 
   </script>

--- a/demo/index.html
+++ b/demo/index.html
@@ -96,6 +96,13 @@ or like this if plus scopes are present
           <option value="profile">Profile info</option>
         </select>
       </div>
+      <div>prompt=
+        <input type="checkbox" checked="{{prompt.none::change}}">none
+        <input type="checkbox" checked="{{prompt.login::change}}">login
+        <input type="checkbox" checked="{{prompt.consent::change}}">consent
+        <input type="checkbox"
+            checked="{{prompt.select_account::change}}">select_account
+      </div>
       <div>offline=<input type="checkbox" checked="{{offline::change}}"></div>
       <div>signedIn="<span>{{signedIn}}</span>"</div>
       <div>isAuthorized="<span>{{isAuthorized}}</span>"</div>
@@ -107,6 +114,7 @@ or like this if plus scopes are present
     </p>
     <google-signin-aware
         scopes="{{scope}}"
+        prompt="{{promptValue}}"
         signed-in="{{signedIn}}"
         offline="{{offline}}"
         is-authorized="{{isAuthorized}}"
@@ -124,6 +132,7 @@ or like this if plus scopes are present
     aware.status = 'Not granted';
     aware.offlineCode = 'No offline login.';
     aware.userName = 'N/A';
+    aware.prompt = {};
     aware.handleSignIn = function(response) {
       this.status = 'Signin granted';
       // console.log('[Aware] Signin Response', response);
@@ -145,6 +154,30 @@ or like this if plus scopes are present
       }
       gapi.auth2.getAuthInstance().signOut();
     };
+
+    aware.addEventListener('prompt-changed', function (e) {
+      if (e.detail.value) {
+        if (e.detail.path === 'prompt.none') {
+          aware.set('prompt', {
+            none: true,
+            login: false,
+            consent: false,
+            select_account: false
+          });
+        } else {
+          aware.set('prompt.none', false);
+        }
+      }
+
+      var values = [];
+      Object.keys(aware.prompt).forEach(function(k) {
+        if (aware.prompt[k]) {
+          values.push(k);
+        }
+      });
+      //this.promptValue = values.join(' ');
+      this.set('promptValue', values.join(' '))
+    });
 
   </script>
 </body>

--- a/google-signin-aware.html
+++ b/google-signin-aware.html
@@ -132,9 +132,13 @@
         }
         if (val) {
           var values = val.split(' ');
-          values = values.map(function(v) { return v.trim(); });
-          values = values.filter(function(v) { return v; });
-          var validValues = {none:0, login:0, consent: 0, select_account:0};
+          values = values.map(function(v) {
+            return v.trim();
+          });
+          values = values.filter(function(v) {
+            return v;
+          });
+          var validValues = {none: 0, login: 0, consent: 0, select_account: 0};
           values.forEach(function(v) {
             if (v == 'none' && values.length > 1) {
               throw new Error(

--- a/google-signin-aware.html
+++ b/google-signin-aware.html
@@ -13,8 +13,9 @@
       'appPackageName': 'apppackagename',
       'clientId': 'clientid',
       'cookiePolicy': 'cookiepolicy',
-      'requestVisibleActions': 'requestvisibleactions',
-      'hostedDomain': 'hostedDomain'
+      'hostedDomain': 'hostedDomain',
+      'prompt': 'prompt',
+      'requestVisibleActions': 'requestvisibleactions'
     };
 
     /**
@@ -113,6 +114,37 @@
         }
         if (val)
           this._hostedDomain = val;
+      },
+
+     /**
+       * oauth2 argument, set by google-signin-aware
+       */
+      _prompt: '',
+
+      get prompt() {
+        return this._prompt;
+      },
+
+      set prompt(val) {
+        if (typeof val !== 'string') {
+          throw new Error('prompt must be a string. Received ' + typeof val);
+        }
+        if (val) {
+          var validValues = {none:0, login:0, consent: 0, select_account:0};
+          var values = val.trim().split();
+          values.forEach(function(v) {
+            if (v == 'none' && values.length > 1) {
+              throw new Error(
+                  'none cannot be combined with other prompt values');
+            }
+            if (!(v in validValues)) {
+              throw new Error(
+                  'invalid prompt value ' + v +
+                  '. Valid values: ' + Object.keys(validValues).join(', '));
+            }
+          });
+        }
+        this._prompt = val;
       },
 
       /** Is offline access currently enabled in the google-signin-aware element? */
@@ -591,6 +623,26 @@ You can bind to `isAuthorized` property to monitor authorization state.
         },
 
         /**
+         * Space-delimited, case-sensitive list of strings that
+         * specifies whether the the user is prompted for reauthentication
+         * and/or consent. The defined values are:
+         *   none: do not display authentication or consent pages.
+         *     This value is mutually exclusive with the rest.
+         *   login: always prompt the user for reauthentication.
+         *   consent: always show consent screen.
+         *   select_account: always show account selection page.
+         *     This enables a user who has multiple accounts to select amongst
+         *     the multiple accounts that they might have current sessions for.
+         * For more information, see "prompt" parameter description in
+         * https://openid.net/specs/openid-connect-basic-1_0.html#RequestParameters
+         */
+        prompt: {
+          type: String,
+          value: '',
+          observer: '_promptChanged'
+        },
+
+        /**
          * True if user is signed in
          */
         signedIn: {
@@ -678,6 +730,10 @@ You can bind to `isAuthorized` property to monitor authorization state.
       _scopesChanged: function(newVal, oldVal) {
         AuthEngine.requestScopes(newVal);
         this._updateScopeStatus();
+      },
+
+      _promptChanged: function(newVal, oldVal) {
+        AuthEngine.prompt = newVal;
       },
 
       _updateScopeStatus: function(user) {

--- a/google-signin-aware.html
+++ b/google-signin-aware.html
@@ -14,7 +14,7 @@
       'clientId': 'clientid',
       'cookiePolicy': 'cookiepolicy',
       'hostedDomain': 'hostedDomain',
-      'prompt': 'prompt',
+      'openidPrompt': 'prompt',
       'requestVisibleActions': 'requestvisibleactions'
     };
 
@@ -119,15 +119,16 @@
      /**
        * oauth2 argument, set by google-signin-aware
        */
-      _prompt: '',
+      _openidPrompt: '',
 
-      get prompt() {
-        return this._prompt;
+      get openidPrompt() {
+        return this._openidPrompt;
       },
 
-      set prompt(val) {
+      set openidPrompt(val) {
         if (typeof val !== 'string') {
-          throw new Error('prompt must be a string. Received ' + typeof val);
+          throw new Error(
+              'openidPrompt must be a string. Received ' + typeof val);
         }
         if (val) {
           var values = val.split(' ');
@@ -137,16 +138,16 @@
           values.forEach(function(v) {
             if (v == 'none' && values.length > 1) {
               throw new Error(
-                  'none cannot be combined with other prompt values');
+                  'none cannot be combined with other openidPrompt values');
             }
             if (!(v in validValues)) {
               throw new Error(
-                  'invalid prompt value ' + v +
+                  'invalid openidPrompt value ' + v +
                   '. Valid values: ' + Object.keys(validValues).join(', '));
             }
           });
         }
-        this._prompt = val;
+        this._openidPrompt = val;
       },
 
       /** Is offline access currently enabled in the google-signin-aware element? */
@@ -638,10 +639,10 @@ You can bind to `isAuthorized` property to monitor authorization state.
          * For more information, see "prompt" parameter description in
          * https://openid.net/specs/openid-connect-basic-1_0.html#RequestParameters
          */
-        prompt: {
+        openidPrompt: {
           type: String,
           value: '',
-          observer: '_promptChanged'
+          observer: '_openidPromptChanged'
         },
 
         /**
@@ -734,8 +735,8 @@ You can bind to `isAuthorized` property to monitor authorization state.
         this._updateScopeStatus();
       },
 
-      _promptChanged: function(newVal, oldVal) {
-        AuthEngine.prompt = newVal;
+      _openidPromptChanged: function(newVal, oldVal) {
+        AuthEngine.openidPrompt = newVal;
       },
 
       _updateScopeStatus: function(user) {

--- a/google-signin-aware.html
+++ b/google-signin-aware.html
@@ -130,8 +130,10 @@
           throw new Error('prompt must be a string. Received ' + typeof val);
         }
         if (val) {
+          var values = val.split(' ');
+          values = values.map(function(v) { return v.trim(); });
+          values = values.filter(function(v) { return v; });
           var validValues = {none:0, login:0, consent: 0, select_account:0};
-          var values = val.trim().split();
           values.forEach(function(v) {
             if (v == 'none' && values.length > 1) {
               throw new Error(

--- a/google-signin.html
+++ b/google-signin.html
@@ -20,6 +20,7 @@
       offline="{{offline}}"
       offline-always-prompt="{{offlineAlwaysPrompt}}"
       scopes="{{scopes}}"
+      prompt="{{prompt}}"
       signed-in="{{signedIn}}"
       is-authorized="{{isAuthorized}}"
       need-additional-auth="{{needAdditionalAuth}}"
@@ -365,6 +366,25 @@ any apps you're building. See the Google Developers Console
          * and should be space-delimited.
          */
         scopes: {
+          type: String,
+          value: ''
+        },
+
+        /**
+         * Space-delimited, case-sensitive list of strings that
+         * specifies whether the the user is prompted for reauthentication
+         * and/or consent. The defined values are:
+         *   none: do not display authentication or consent pages.
+         *     This value is mutually exclusive with the rest.
+         *   login: always prompt the user for reauthentication.
+         *   consent: always show consent screen.
+         *   select_account: always show account selection page.
+         *     This enables a user who has multiple accounts to select amongst
+         *     the multiple accounts that they might have current sessions for.
+         * For more information, see "prompt" parameter description in
+         * https://openid.net/specs/openid-connect-basic-1_0.html#RequestParameters
+         */
+        prompt: {
           type: String,
           value: ''
         },

--- a/google-signin.html
+++ b/google-signin.html
@@ -20,7 +20,7 @@
       offline="{{offline}}"
       offline-always-prompt="{{offlineAlwaysPrompt}}"
       scopes="{{scopes}}"
-      prompt="{{prompt}}"
+      openid-prompt="{{openidPrompt}}"
       signed-in="{{signedIn}}"
       is-authorized="{{isAuthorized}}"
       need-additional-auth="{{needAdditionalAuth}}"
@@ -384,7 +384,7 @@ any apps you're building. See the Google Developers Console
          * For more information, see "prompt" parameter description in
          * https://openid.net/specs/openid-connect-basic-1_0.html#RequestParameters
          */
-        prompt: {
+        openidPrompt: {
           type: String,
           value: ''
         },


### PR DESCRIPTION
Add prompt property to <google-signin> and <google-signin-aware>
elements. Its docs:

```
  Space-delimited, case-sensitive list of strings that
  specifies whether the the user is prompted for reauthentication
  and/or consent. The defined values are:
    none: do not display authentication or consent pages.
      This value is mutually exclusive with the rest.
    login: always prompt the user for reauthentication.
    consent: always show consent screen.
    select_account: always show account selection page.
      This enables a user who has multiple accounts to select amongst
      the multiple accounts that they might have current sessions for.
  For more information, see "prompt" parameter description in
  https://openid.net/specs/openid-connect-basic-1_0.html#RequestParameters
```

Updated demo and used it to test.

Fixes #128