### PR TITLE
Move to iron-flex-layout-classes

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -26,7 +26,6 @@
     "font-roboto": "PolymerElements/font-roboto#^1.0.0",
     "iron-icon": "PolymerElements/iron-icon#^1.0.0",
     "iron-iconset-svg": "PolymerElements/iron-iconset-svg#^1.0.0",
-    "iron-flex-layout": "PolymerElements/iron-flex-layout#^1.0.0",
     "paper-ripple": "PolymerElements/paper-ripple#^1.0.0",
     "paper-material": "PolymerElements/paper-material#^1.0.0",
     "google-apis": "GoogleWebComponents/google-apis#^1.0.0"

--- a/bower.json
+++ b/bower.json
@@ -26,6 +26,7 @@
     "font-roboto": "PolymerElements/font-roboto#^1.0.0",
     "iron-icon": "PolymerElements/iron-icon#^1.0.0",
     "iron-iconset-svg": "PolymerElements/iron-iconset-svg#^1.0.0",
+    "iron-flex-layout": "PolymerElements/iron-flex-layout#^1.3.0",
     "paper-ripple": "PolymerElements/paper-ripple#^1.0.0",
     "paper-material": "PolymerElements/paper-material#^1.0.0",
     "google-apis": "GoogleWebComponents/google-apis#^1.0.0"

--- a/google-signin.html
+++ b/google-signin.html
@@ -5,9 +5,11 @@
 <link rel="import" href="../google-apis/google-js-api.html">
 <link rel="import" href="../paper-ripple/paper-ripple.html">
 <link rel="import" href="../paper-material/paper-material.html">
+<link rel="import" href="../iron-flex-layout/iron-flex-layout-classes.html">
 <link rel="import" href="google-icons.html">
 
 <dom-module id="google-signin">
+  <style is="custom-style" include="iron-positioning"></style>
   <link rel="import" type="css" href="google-signin.css">
   <template>
     <google-signin-aware id="aware"

--- a/google-signin.html
+++ b/google-signin.html
@@ -9,9 +9,10 @@
 <link rel="import" href="google-icons.html">
 
 <dom-module id="google-signin">
-  <style is="custom-style" include="iron-positioning"></style>
   <link rel="import" type="css" href="google-signin.css">
   <template>
+    <style is="custom-style" include="iron-positioning"></style>
+
     <google-signin-aware id="aware"
       app-package-name="{{appPackageName}}"
       client-id="{{clientId}}"

--- a/google-signin.html
+++ b/google-signin.html
@@ -5,7 +5,6 @@
 <link rel="import" href="../google-apis/google-js-api.html">
 <link rel="import" href="../paper-ripple/paper-ripple.html">
 <link rel="import" href="../paper-material/paper-material.html">
-<link rel="import" href="../iron-flex-layout/classes/iron-flex-layout.html">
 <link rel="import" href="google-icons.html">
 
 <dom-module id="google-signin">
@@ -33,7 +32,7 @@
 
       <paper-ripple id="ripple" class="fit"></paper-ripple>
       <!-- this div is needed to position the ripple behind text content -->
-      <div relative layout horizontal center-center>
+      <div>
         <template is="dom-if" if="{{_computeButtonIsSignIn(signedIn, needAdditionalAuth)}}">
           <div class="button-content signIn" tabindex="0"
               on-click="signIn" on-keydown="_signInKeyPress">


### PR DESCRIPTION
As far as I can tell, the `PolymerElements/iron-flex-layout` was never used in the 1.x rewrite.

There's a carryover with the old-style `<div relative layout horizontal center-center>` attributes that I'm also removing, since they're no-ops in 1.x.

I'm assuming that this is just some cruft leftover from the 1.x migration.

The button looks unchanged to me (though you need to resolve #133 before you can test it locally).

Closes #132 