### PR TITLE
Fire a new google-signin-aware-error

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -119,6 +119,7 @@ or like this if plus scopes are present
         offline="{{offline}}"
         is-authorized="{{isAuthorized}}"
         need-additional-auth="{{needAdditionalAuth}}"
+        on-google-signin-aware-error="handleSignInError"
         on-google-signin-aware-success="handleSignIn"
         on-google-signin-offline-success="handleOffline"
         on-google-signin-aware-signed-out="handleSignOut"></google-signin-aware>
@@ -133,6 +134,9 @@ or like this if plus scopes are present
     aware.offlineCode = 'No offline login.';
     aware.userName = 'N/A';
     aware.openidPrompt = {};
+    aware.handleSignInError = function(event) {
+      this.status = JSON.stringify(event.detail);
+    };
     aware.handleSignIn = function(response) {
       this.status = 'Signin granted';
       // console.log('[Aware] Signin Response', response);

--- a/google-signin-aware.html
+++ b/google-signin-aware.html
@@ -460,13 +460,13 @@
             // Let the current user listener trigger the changes.
           },
           function error(error) {
-            if ("Access denied." == error.reason) {
-              // Access denied is not an error, user hit cancel
-              return;
-            } else {
-              console.error(error);
+            // Access denied is not an error, user hit cancel
+            if ("Access denied." !== error.reason) {
+              this.signinAwares.forEach(function(awareInstance) {
+                awareInstance.fire('google-signin-aware-error', error);
+              });
             }
-          }
+          }.bind(this)
         );
       },
 
@@ -547,6 +547,11 @@ You can bind to `isAuthorized` property to monitor authorization state.
       /**
        * Fired when this scope is not authorized
        * @event google-signin-aware-signed-out
+       */
+      /**
+       * Fired when there is an error during the signin flow.
+       * @param {Object} detail The error object returned from the OAuth 2 flow.
+       * @event google-signin-aware-error
        */
       properties: {
         /**

--- a/google-signin-aware.html
+++ b/google-signin-aware.html
@@ -463,7 +463,7 @@
             // Access denied is not an error, user hit cancel
             if ("Access denied." !== error.reason) {
               this.signinAwares.forEach(function(awareInstance) {
-                awareInstance.fire('google-signin-aware-error', error);
+                awareInstance.errorNotify(error);
               });
             }
           }.bind(this)
@@ -709,6 +709,10 @@ You can bind to `isAuthorized` property to monitor authorization state.
       /** signs user out */
       signOut: function() {
         AuthEngine.signOut();
+      },
+
+      errorNotify: function(error) {
+        this.fire('google-signin-aware-error', error);
       },
 
       _appPackageNameChanged: function(newName, oldName) {

--- a/google-signin.html
+++ b/google-signin.html
@@ -212,6 +212,12 @@ any apps you're building. See the Google Developers Console
      */
 
     /**
+     * Fired when there is an error during the signin flow.
+     * @param {Object} detail The error object returned from the OAuth 2 flow.
+     * @event google-signin-aware-error
+     */
+
+    /**
      * Fired when an offline authorization is successful.
      * @event google-signin-offline-success
      * @param {Object} detail


### PR DESCRIPTION
R: @addyosmani @Zoramite etc.

There's a pattern in this element of calling `console.error()` if something prevented signin from succeeding, but not communicating that failure to the page. This PR handles one specific type of error that I can reproduce reliably and which host pages would want to know about, and fires a new `google-signin-aware-error` event with the error details when it occurs.

The particular error occurs when you request the YouTube scope and auth as a Google+ Page, which is a regression in the underlying Google Auth library. That regression is being tracked internally, and hopefully the underlying issue with be resolved at some point, but in the meantime, I'd really like to be able to detect the failure via this new event.

I'll leave it up to the folks who know more about the element to determine whether it makes sense to replace some of the various `throw` and `console.error()` statements with a formal error event.