### PR TITLE
Fix firing google-signed-out at initialization

### DIFF
--- a/google-signin.html
+++ b/google-signin.html
@@ -495,12 +495,16 @@ any apps you're building. See the Google Developers Console
 
       _observeSignedIn: function(newVal, oldVal) {
         if (newVal) {
-          if (this.needAdditionalAuth)
+          if (this.needAdditionalAuth) {
             this.fire('google-signin-necessary');
+          }
           this.fire('google-signin-success');
         }
-        else
+        // Use `oldVal` avoids to fire the event at the initialization of
+        // `signedIn`.
+        else if (oldVal) {
           this.fire('google-signed-out');
+        }
       },
 
       /**


### PR DESCRIPTION
This commit avoids to fire the google-signed-out event when the element
initializes its property "signedIn". When the element is created, its
property "signedIn" changes from "undefined" to "false". At this time,
it shouldn't send event. It's the reason why I added the condition on
the previous value.

fixes #139
