### PR TITLE
Replacing @type declarations to avoid JSCompiler issues

### DIFF
--- a/google-signin.html
+++ b/google-signin.html
@@ -295,7 +295,7 @@ any apps you're building. See the Google Developers Console
          *
          * Available options: short, standard, tall.
          *
-         * @type {HeightValue}
+         * @type {string}
          */
         height: {
           type: String,
@@ -418,7 +418,7 @@ any apps you're building. See the Google Developers Console
          * Available options: light, dark.
          *
          * @attribute theme
-         * @type {ThemeValue}
+         * @type {string}
          * @default 'dark'
          */
         theme: {
@@ -431,7 +431,7 @@ any apps you're building. See the Google Developers Console
          *
          * Available options: iconOnly, standard, wide.
          *
-         * @type {WidthValue}
+         * @type {string}
          */
         width: {
           type: String,


### PR DESCRIPTION
Replacing @type declarations to use underlying base type instead of enums. Otherwise, the JSCompiler throws errors that the declared @enum types are unknown during compilation. Polymer doesn't enforce enums anyway.