### PR TITLE
Add initialized property to detect when auth library has initialized

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -104,6 +104,7 @@ or like this if plus scopes are present
             checked="{{openidPrompt.select_account::change}}">select_account
       </div>
       <div>offline=<input type="checkbox" checked="{{offline::change}}"></div>
+      <div>initialized="<span>{{initialized}}</span>"</div>
       <div>signedIn="<span>{{signedIn}}</span>"</div>
       <div>isAuthorized="<span>{{isAuthorized}}</span>"</div>
       <div>needAdditionalAuth:"<span>{{needAdditionalAuth}}</span>"&gt;</div>
@@ -115,6 +116,7 @@ or like this if plus scopes are present
     <google-signin-aware
         scopes="{{scope}}"
         openid-prompt="{{openidPromptValue}}"
+        initialized="{{initialized}}"
         signed-in="{{signedIn}}"
         offline="{{offline}}"
         is-authorized="{{isAuthorized}}"
@@ -122,10 +124,13 @@ or like this if plus scopes are present
         on-google-signin-aware-error="handleSignInError"
         on-google-signin-aware-success="handleSignIn"
         on-google-signin-offline-success="handleOffline"
-        on-google-signin-aware-signed-out="handleSignOut"></google-signin-aware>
+        on-google-signin-aware-signed-out="handleSignOut"
+        on-signed-in-changed="handleStateChange"
+        on-initialized-changed="handleStateChange"></google-signin-aware>
     <p>User name:<span>{{userName}}</span></p>
     <p>Testing <code>google-signin-aware</code> events: <span>{{status}}</span></p>
     <p>Testing <code>google-signin-offline</code> events: <span>{{offlineCode}}</span></p>
+    <p>Only display "not signed in" element after auth state is initialized (avoid flickering): <b hidden id="not-signed-in">Not signed in!</b></p>
     <p><button on-click="disconnect">Disconnect to start over</button></p>
   </template>
   <script>
@@ -157,6 +162,16 @@ or like this if plus scopes are present
         currentUser.disconnect();
       }
       gapi.auth2.getAuthInstance().signOut();
+    };
+
+    aware.handleStateChange = function(e) {
+      var signedIn = e.target.signedIn;
+      var initialized = e.target.initialized;
+      if(initialized && !signedIn) {
+        document.querySelector("#not-signed-in").removeAttribute("hidden");
+      } else {
+        document.querySelector("#not-signed-in").setAttribute("hidden", true);
+      }
     };
 
     aware.addEventListener('openid-prompt-changed', function(e) {

--- a/google-signin-aware.html
+++ b/google-signin-aware.html
@@ -208,6 +208,9 @@ limitations under the License.
         return this._requestedScopeArray.join(' ');
       },
 
+      /** Is auth library initalized? */
+      _initialized: false,
+
       /** Is user signed in? */
       _signedIn: false,
 
@@ -267,6 +270,14 @@ limitations under the License.
             this.signinAwares[i]._setSignedIn(isSignedIn);
           }
         }
+        // update and broadcast initialized property the first time the isSignedIn property is set.
+        if(!this._initialized) {
+            for (var i=0; i<this.signinAwares.length; i++) {
+                this.signinAwares[i]._setInitialized(true);
+            }
+            this._initialized = true;
+        }
+
 
         // update granted scopes
         this._grantedScopeArray = this.strToScopeArray(
@@ -387,6 +398,7 @@ limitations under the License.
           this.signinAwares.push(aware);
           // Initialize aware properties
           aware._setNeedAdditionalAuth(this._needAdditionalAuth);
+          aware._setInitialized(this._initialized);
           aware._setSignedIn(this._signedIn);
           aware._setHasPlusScopes(this._hasPlusScopes);
         } else {
@@ -677,6 +689,15 @@ You can bind to `isAuthorized` property to monitor authorization state.
           type: String,
           value: '',
           observer: '_openidPromptChanged'
+        },
+
+        /**
+         * True when the auth library has been initialized, and signedIn property value is set from the first api response.
+         */
+        initialized: {
+            type: Boolean,
+            notify: true,
+            readOnly: true
         },
 
         /**

--- a/google-signin.html
+++ b/google-signin.html
@@ -38,6 +38,7 @@ limitations under the License.
       offline-always-prompt="{{offlineAlwaysPrompt}}"
       scopes="{{scopes}}"
       openid-prompt="{{openidPrompt}}"
+      initialized="{{initialized}}"
       signed-in="{{signedIn}}"
       is-authorized="{{isAuthorized}}"
       need-additional-auth="{{needAdditionalAuth}}"
@@ -456,6 +457,15 @@ any apps you're building. See the Google Developers Console
          * True if additional authorization required globally
          */
         needAdditionalAuth: {
+          type: Boolean,
+          notify: true,
+          value: false
+        },
+
+        /**
+         * True when the auth library has been initialized, and signedIn property value is set from the first api response.
+         */
+        initialized: {
           type: Boolean,
           notify: true,
           value: false


### PR DESCRIPTION
To be able to easily display something like a dialog when user is not signed in, we need to know when the signedIn property is set based on first reponse from auth library rather than the default false value.

Adding a property such as this change does makes this possible.

I believe this solves issue #137 and #121 as well as my own need for such a feature.
