### PR TITLE
1 simple bug fix + `login_hint` support

### DIFF
--- a/google-signin-aware.html
+++ b/google-signin-aware.html
@@ -61,7 +61,9 @@ limitations under the License.
         }
         if (val && val != this._clientId) {
           this._clientId = val;
-          this.initAuth2();
+          if ('gapi' in window) {
+            this.initAuth2();
+          }
         }
       },
 

--- a/google-signin-aware.html
+++ b/google-signin-aware.html
@@ -425,10 +425,11 @@ limitations under the License.
       },
 
       /** pops up sign-in dialog */
-      signIn: function() {
+      signIn: function(id) {
         this.assertAuthInitialized();
         var params = {
-          'scope': this.getMissingScopes()
+          'scope': this.getMissingScopes(),
+          'login_hint': id || ''
         };
 
         // Proxy specific attributes through to the signIn options.
@@ -729,8 +730,8 @@ You can bind to `isAuthorized` property to monitor authorization state.
       },
 
       /** pops up the authorization dialog */
-      signIn: function() {
-        AuthEngine.signIn();
+      signIn: function(id) {
+        AuthEngine.signIn(id);
       },
 
       /** signs user out */


### PR DESCRIPTION
This PR includes 2 changes.
1. Fix a simple bug fix that fails on initialization when trying to use `google-signin-aware` with `client_id` directly added as an attribute.
2. Added `login_hint` which let you specify identity to sign in so users can skip account chooser UI.