### PR TITLE
2.0 hybridity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
-bower_components
+bower_components*
+bower-*.json

--- a/bower.json
+++ b/bower.json
@@ -22,16 +22,33 @@
     "authentication"
   ],
   "dependencies": {
-    "polymer": "Polymer/polymer#^1.0.0",
+    "polymer": "Polymer/polymer#^2.0.0-rc.1",
     "font-roboto": "PolymerElements/font-roboto#^1.0.0",
-    "iron-icon": "PolymerElements/iron-icon#^1.0.0",
-    "iron-iconset-svg": "PolymerElements/iron-iconset-svg#^1.0.0",
-    "iron-flex-layout": "PolymerElements/iron-flex-layout#^1.3.0",
-    "paper-ripple": "PolymerElements/paper-ripple#^1.0.0",
-    "paper-material": "PolymerElements/paper-material#^1.0.0",
-    "google-apis": "GoogleWebComponents/google-apis#^1.0.0"
+    "iron-icon": "PolymerElements/iron-icon#2.0-preview",
+    "iron-iconset-svg": "PolymerElements/iron-iconset-svg#2.0-preview",
+    "iron-flex-layout": "PolymerElements/iron-flex-layout#2.0-preview",
+    "paper-ripple": "PolymerElements/paper-ripple#2.0-preview",
+    "paper-material": "PolymerElements/paper-material#2.0-preview",
+    "google-apis": "GoogleWebComponents/google-apis#2.0-preview"
   },
   "devDependencies": {
-    "iron-component-page": "PolymerElements/iron-component-page#^1.0.2"
+    "iron-component-page": "PolymerElements/iron-component-page#2.0-preview"
+  },
+  "variants": {
+    "1.x": {
+      "dependencies": {
+        "polymer": "Polymer/polymer#^1.0.0",
+        "font-roboto": "PolymerElements/font-roboto#^1.0.0",
+        "iron-icon": "PolymerElements/iron-icon#^1.0.0",
+        "iron-iconset-svg": "PolymerElements/iron-iconset-svg#^1.0.0",
+        "iron-flex-layout": "PolymerElements/iron-flex-layout#^1.3.0",
+        "paper-ripple": "PolymerElements/paper-ripple#^1.0.0",
+        "paper-material": "PolymerElements/paper-material#^1.0.0",
+        "google-apis": "GoogleWebComponents/google-apis#^1.0.0"
+      },
+      "devDependencies": {
+        "iron-component-page": "PolymerElements/iron-component-page#^1.0.0"
+      }
+    }
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "google-signin",
-  "version": "1.3.7",
+  "version": "2.0.0",
   "description": "Web components to authenticate with Google services",
   "homepage": "https://googlewebcomponents.github.io/google-signin",
   "main": "google-signin.html",
@@ -22,17 +22,17 @@
     "authentication"
   ],
   "dependencies": {
-    "polymer": "Polymer/polymer#^2.0.0-rc.1",
+    "polymer": "Polymer/polymer#1.9 - 2",
     "font-roboto": "PolymerElements/font-roboto#^1.0.0",
-    "iron-icon": "PolymerElements/iron-icon#2.0-preview",
-    "iron-iconset-svg": "PolymerElements/iron-iconset-svg#2.0-preview",
-    "iron-flex-layout": "PolymerElements/iron-flex-layout#2.0-preview",
-    "paper-ripple": "PolymerElements/paper-ripple#2.0-preview",
-    "paper-material": "PolymerElements/paper-material#2.0-preview",
-    "google-apis": "GoogleWebComponents/google-apis#2.0-preview"
+    "iron-icon": "PolymerElements/iron-icon#1 - 2",
+    "iron-iconset-svg": "PolymerElements/iron-iconset-svg#1 - 2",
+    "iron-flex-layout": "PolymerElements/iron-flex-layout#1 - 2",
+    "paper-ripple": "PolymerElements/paper-ripple#1 - 2",
+    "paper-material": "PolymerElements/paper-material#1 - 2",
+    "google-apis": "GoogleWebComponents/google-apis#1 - 2"
   },
   "devDependencies": {
-    "iron-component-page": "PolymerElements/iron-component-page#2.0-preview"
+    "iron-component-page": "PolymerElements/iron-component-page#1 - 2"
   },
   "variants": {
     "1.x": {

--- a/demo/index.html
+++ b/demo/index.html
@@ -84,61 +84,68 @@ or like this if plus scopes are present
   <p>Every signin button will request all the scopes present in the document,
   and change its appearance to match</p>
   <p>For example, here is a signin-aware scope. You can change its scopes via popup</p>
-  <template id="awareness" is="dom-bind">
-    <div><code>&lt;google-signin-aware
-      <div>scope=
-        <select value="{{scope::change}}">
-          <option value="">None</option>
-          <option value="https://www.googleapis.com/auth/analytics">Google Analytics</option>
-          <option value="https://www.googleapis.com/auth/plus.login">Google Plus view circles</option>
-          <option value="https://www.googleapis.com/auth/youtube">YouTube</option>
-          <option value="https://www.googleapis.com/auth/calendar">Calendar</option>
-          <option value="profile">Profile info</option>
-        </select>
-      </div>
-      <div>openid-prompt=
-        <input type="checkbox" checked="{{openidPrompt.none::change}}">none
-        <input type="checkbox" checked="{{openidPrompt.login::change}}">login
-        <input type="checkbox" checked="{{openidPrompt.consent::change}}">consent
-        <input type="checkbox"
-            checked="{{openidPrompt.select_account::change}}">select_account
-      </div>
-      <div>offline=<input type="checkbox" checked="{{offline::change}}"></div>
-      <div>initialized="<span>{{initialized}}</span>"</div>
-      <div>signedIn="<span>{{signedIn}}</span>"</div>
-      <div>isAuthorized="<span>{{isAuthorized}}</span>"</div>
-      <div>needAdditionalAuth:"<span>{{needAdditionalAuth}}</span>"&gt;</div>
-    </code></div>
-    <p>Every new scope you select will be added to requested scopes.</p>
-    <p>When you select a Google Plus scope, button will turn red.</p>
-      <google-signin></google-signin>
-    </p>
-    <google-signin-aware
-        scopes="{{scope}}"
-        openid-prompt="{{openidPromptValue}}"
-        initialized="{{initialized}}"
-        signed-in="{{signedIn}}"
-        offline="{{offline}}"
-        is-authorized="{{isAuthorized}}"
-        need-additional-auth="{{needAdditionalAuth}}"
-        on-google-signin-aware-error="handleSignInError"
-        on-google-signin-aware-success="handleSignIn"
-        on-google-signin-offline-success="handleOffline"
-        on-google-signin-aware-signed-out="handleSignOut"
-        on-signed-in-changed="handleStateChange"
-        on-initialized-changed="handleStateChange"></google-signin-aware>
-    <p>User name:<span>{{userName}}</span></p>
-    <p>Testing <code>google-signin-aware</code> events: <span>{{status}}</span></p>
-    <p>Testing <code>google-signin-offline</code> events: <span>{{offlineCode}}</span></p>
-    <p>Only display "not signed in" element after auth state is initialized (avoid flickering): <b hidden id="not-signed-in">Not signed in!</b></p>
-    <p><button on-click="disconnect">Disconnect to start over</button></p>
-  </template>
+  <dom-bind id="awareness">
+    <template is="dom-bind">
+      <div><code>&lt;google-signin-aware
+        <div>scope=
+          <select value="{{scope::change}}">
+            <option value="">None</option>
+            <option value="https://www.googleapis.com/auth/analytics">Google Analytics</option>
+            <option value="https://www.googleapis.com/auth/plus.login">Google Plus view circles</option>
+            <option value="https://www.googleapis.com/auth/youtube">YouTube</option>
+            <option value="https://www.googleapis.com/auth/calendar">Calendar</option>
+            <option value="profile">Profile info</option>
+          </select>
+        </div>
+        <div>openid-prompt=
+          <input type="checkbox" checked="{{openidPrompt.none::change}}">none
+          <input type="checkbox" checked="{{openidPrompt.login::change}}">login
+          <input type="checkbox" checked="{{openidPrompt.consent::change}}">consent
+          <input type="checkbox"
+              checked="{{openidPrompt.select_account::change}}">select_account
+        </div>
+        <div>offline=<input type="checkbox" checked="{{offline::change}}"></div>
+        <div>initialized="<span>{{initialized}}</span>"</div>
+        <div>signedIn="<span>{{signedIn}}</span>"</div>
+        <div>isAuthorized="<span>{{isAuthorized}}</span>"</div>
+        <div>needAdditionalAuth:"<span>{{needAdditionalAuth}}</span>"&gt;</div>
+      </code></div>
+      <p>Every new scope you select will be added to requested scopes.</p>
+      <p>When you select a Google Plus scope, button will turn red.</p>
+        <google-signin></google-signin>
+      </p>
+      <google-signin-aware
+          scopes="{{scope}}"
+          openid-prompt="{{openidPromptValue}}"
+          initialized="{{initialized}}"
+          signed-in="{{signedIn}}"
+          offline="{{offline}}"
+          is-authorized="{{isAuthorized}}"
+          need-additional-auth="{{needAdditionalAuth}}"
+          on-google-signin-aware-error="handleSignInError"
+          on-google-signin-aware-success="handleSignIn"
+          on-google-signin-offline-success="handleOffline"
+          on-google-signin-aware-signed-out="handleSignOut"
+          on-signed-in-changed="handleStateChange"
+          on-initialized-changed="handleStateChange"></google-signin-aware>
+      <p>User name:<span>{{userName}}</span></p>
+      <p>Testing <code>google-signin-aware</code> events: <span>{{status}}</span></p>
+      <p>Testing <code>google-signin-offline</code> events: <span>{{offlineCode}}</span></p>
+      <p>Only display "not signed in" element after auth state is initialized (avoid flickering): <b hidden id="not-signed-in">Not signed in!</b></p>
+      <p><button on-click="disconnect">Disconnect to start over</button></p>
+    </template>
+  </dom-bind>
   <script>
     var aware = document.querySelector('#awareness');
+    if (!Polymer.Element) {
+      aware = aware.querySelector('template');
+    }
+
     aware.status = 'Not granted';
     aware.offlineCode = 'No offline login.';
     aware.userName = 'N/A';
     aware.openidPrompt = {};
+
     aware.handleSignInError = function(event) {
       this.status = JSON.stringify(event.detail);
     };
@@ -156,7 +163,6 @@ or like this if plus scopes are present
       this.userName = 'N/A';
     };
     aware.disconnect = function() {
-      var b = document.querySelector('google-signin');
       var currentUser = gapi.auth2.getAuthInstance().currentUser.get();
       if (currentUser) {
         currentUser.disconnect();

--- a/google-signin-aware.html
+++ b/google-signin-aware.html
@@ -232,6 +232,9 @@ limitations under the License.
       init: function() {
         this._apiLoader = document.createElement('google-js-api');
         this._apiLoader.addEventListener('js-api-load', this.loadAuth2.bind(this));
+        if (Polymer.Element) {
+          document.body.appendChild(this._apiLoader);
+        }
       },
 
       loadAuth2: function() {


### PR DESCRIPTION
This should be merged into a 2.0-preview branch which doesn't exist yet. If you create the branch I can change the PR accordingly.

This also depends on a 2.0-preview branch in google-apis, which doesn't exist yet. For testing I used the version from this PR: https://github.com/GoogleWebComponents/google-apis/pull/79

The main issue for making this work for 2.0 seems to be that the "ready" event doesn't fire unless an element is actually added to the DOM (and not only created), which is why the api-loader needs to be added to the DOM when using the element in 2.0.

This solves https://github.com/GoogleWebComponents/google-signin/issues/158.