### PR TITLE
2.0-preview

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
-bower_components
+bower_components*
+bower-*.json

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "google-signin",
-  "version": "1.3.7",
+  "version": "2.0.0",
   "description": "Web components to authenticate with Google services",
   "homepage": "https://googlewebcomponents.github.io/google-signin",
   "main": "google-signin.html",
@@ -22,16 +22,39 @@
     "authentication"
   ],
   "dependencies": {
-    "polymer": "Polymer/polymer#^1.0.0",
+    "polymer": "Polymer/polymer#1.9 - 2",
     "font-roboto": "PolymerElements/font-roboto#^1.0.0",
-    "iron-icon": "PolymerElements/iron-icon#^1.0.0",
-    "iron-iconset-svg": "PolymerElements/iron-iconset-svg#^1.0.0",
+    "iron-icon": "PolymerElements/iron-icon#1 - 2",
+    "iron-iconset-svg": "PolymerElements/iron-iconset-svg#1 - 2",
     "iron-flex-layout": "PolymerElements/iron-flex-layout#^1.3.0",
-    "paper-ripple": "PolymerElements/paper-ripple#^1.0.0",
-    "paper-material": "PolymerElements/paper-material#^1.0.0",
-    "google-apis": "GoogleWebComponents/google-apis#^1.0.0"
+    "paper-ripple": "PolymerElements/paper-ripple#1 - 2",
+    "paper-material": "PolymerElements/paper-material#1 - 2",
+    "google-apis": "GoogleWebComponents/google-apis#1 - 2"
   },
   "devDependencies": {
-    "iron-component-page": "PolymerElements/iron-component-page#^1.0.2"
+    "iron-component-page": "PolymerElements/iron-component-page#1 - 2"
+  },
+  "variants": {
+    "1.x": {
+      "dependencies": {
+        "polymer": "Polymer/polymer#^1.0.0",
+        "font-roboto": "PolymerElements/font-roboto#^1.0.0",
+        "iron-icon": "PolymerElements/iron-icon#^1.0.0",
+        "iron-iconset-svg": "PolymerElements/iron-iconset-svg#^1.0.0",
+        "iron-flex-layout": "PolymerElements/iron-flex-layout#^1.3.0",
+        "paper-ripple": "PolymerElements/paper-ripple#^1.0.0",
+        "paper-material": "PolymerElements/paper-material#^1.0.0",
+        "google-apis": "GoogleWebComponents/google-apis#^1.0.0"
+      },
+      "devDependencies": {
+        "iron-component-page": "PolymerElements/iron-component-page#^1.0.2"
+      },
+      "resolutions": {
+        "webcomponentsjs": "^0.7"
+      }
+    }
+  },
+  "resolutions": {
+    "webcomponentsjs": "^1.0.0"
   }
 }


### PR DESCRIPTION
The demos worked. On webcomponents.org the demo does not show up, and I don't believe the demo client-id will work on webcomponents.org or on localhost as you have to specify "Authorized JavaScript origins" and "Authorized redirect URIs".

Who controls the google APIs project for the demo @addyosmani @ebidel @Zoramite?

I'll be happy to change it if I can get permissions.