### PR TITLE
Remove warnings and error when depending on google signin library

### DIFF
--- a/google-signin-aware.js
+++ b/google-signin-aware.js
@@ -576,6 +576,7 @@ Polymer({
 
   is: 'google-signin-aware',
 
+  /** @override */
   _template: null,
 
   /**
@@ -757,10 +758,12 @@ Polymer({
     }
   },
 
+  /** @override */
   attached: function() {
     AuthEngine.attachSigninAware(this);
   },
 
+  /** @override */
   detached: function() {
     AuthEngine.detachSigninAware(this);
   },

--- a/google-signin.js
+++ b/google-signin.js
@@ -149,6 +149,7 @@ any apps you're building. See the Google Developers Console
 */
 
 Polymer({
+  /** @override */
   _template: html`
     <style include="google-signin-styles iron-positioning"></style>
 
@@ -415,7 +416,6 @@ Polymer({
      *
      * Available options: light, dark.
      *
-     * @attribute theme
      * @type {string}
      * @default 'dark'
      */


### PR DESCRIPTION
When dependending on these libraries from our package, we get warnings like:
WARNING - [JSC_HIDDEN_INTERFACE_PROPERTY] property _template already defined on interface Polymer_ElementMixin; use @override to override it
  _template: html`

Also get this error:
ERROR - [JSC_BAD_JSDOC_ANNOTATION] Parse error. illegal use of unknown JSDoc tag "attribute"; ignoring it
     * @attribute theme

This change is to add the recommended @override and remove the offending @attribute.